### PR TITLE
Ignore w:pict

### DIFF
--- a/docx/from/docxtotei.xsl
+++ b/docx/from/docxtotei.xsl
@@ -704,4 +704,9 @@ of this software, even if advised of the possibility of such damage.
       </xsl:attribute>
     </xsl:template>
     
+
+
+    <!-- We cannot process these elements. -->
+    <xsl:template match="w:pict">
+    </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
The template parameters $extrarow and $extracolumn, which are required
for table processing, where not being sent to the table processing
templates which were called from beneath w:pict elements. Since w:pict
contains content that we cannot process, simply ignore it.
