### PR TITLE
APERTA-7082 Fix problem when processing field.

### DIFF
--- a/docx/from/paragraphs.xsl
+++ b/docx/from/paragraphs.xsl
@@ -300,7 +300,7 @@ of this software, even if advised of the possibility of such damage.
 		</xsl:for-each>
 	      </xsl:when>
 	      <xsl:otherwise>
-		<xsl:apply-templates select="current-group()"/>
+		<xsl:apply-templates select="current-group()/.."/>
 	      </xsl:otherwise>
 	    </xsl:choose>
 	  </xsl:for-each-group>


### PR DESCRIPTION
Complex fields are delimited by `w:fldChar` elements with
`w:fldCharType` attributes with the value `begin`, `separate` or `end`.

After finding the end element, the sibling elements still need to be
processed, but we want, it seems, to process the parents in order to get
the right stylesheets, not the captured groups.
