### PR TITLE
Bugs/aperta 7367 caption text

### DIFF
--- a/html/html_figures.xsl
+++ b/html/html_figures.xsl
@@ -313,7 +313,11 @@ of this software, even if advised of the possibility of such damage.
      -->
      <xsl:if test="tei:head and name(*[1]) = 'head'">
 	     <caption class="above">
-	       <xsl:apply-templates select="tei:head"/>
+          <xsl:for-each select="tei:head">
+            <p>
+              <xsl:apply-templates />
+            </p>
+          </xsl:for-each>
 	     </caption>
 	   </xsl:if>
 
@@ -325,7 +329,11 @@ of this software, even if advised of the possibility of such damage.
      -->
      <xsl:if test="tei:head and name(*[1]) != 'head'">
 	     <caption class="below">
-	       <xsl:apply-templates select="tei:head"/>
+          <xsl:for-each select="tei:head">
+            <p>
+              <xsl:apply-templates />
+            </p>
+          </xsl:for-each>
 	     </caption>
 	   </xsl:if>
 

--- a/html/html_figures.xsl
+++ b/html/html_figures.xsl
@@ -304,11 +304,31 @@ of this software, even if advised of the possibility of such damage.
 	       <xsl:copy-of select="."/>
 	     </xsl:if>
 	   </xsl:for-each>
-	   <xsl:if test="tei:head">
-	     <caption>
+
+	   <!--
+      For caption placement above the corresponding table or figure
+      this checks to see if the first element is a <head> element. If it is,
+      we assume placement is intended to at the top of the current table
+      appearing above the content.
+     -->
+     <xsl:if test="tei:head and name(*[1]) = 'head'">
+	     <caption class="above">
 	       <xsl:apply-templates select="tei:head"/>
 	     </caption>
 	   </xsl:if>
+
+	   <!--
+      For caption placement below the corresponding table or figure
+      this checks to see if the first element is NOT a <head> element.
+      If it isn't, we assume placement is intended to at the bottom of the
+      current table appearing beneath the content.
+     -->
+     <xsl:if test="tei:head and name(*[1]) != 'head'">
+	     <caption class="below">
+	       <xsl:apply-templates select="tei:head"/>
+	     </caption>
+	   </xsl:if>
+
 	   <xsl:choose>
 	     <xsl:when test="tei:row[tei:match(@rend,'thead')]">
 	       <thead>


### PR DESCRIPTION
Fixes problems with how HTML5 places caption text.
- Captions that appear at the top of a table are given a class of `above` 
- Captions that appear below a table are given a class of `below`
- Multiple captions in either place are wrapped in `<p>` tags to preserve line breaks. 

The CSS that will place the captions above or below the table will be handled in a separate pull request in the tahi repo.
